### PR TITLE
feat: Add OrganizationUser relationship management/table

### DIFF
--- a/ems-back.Repo/DTOs/CreateOrganizationUserDto.cs
+++ b/ems-back.Repo/DTOs/CreateOrganizationUserDto.cs
@@ -1,0 +1,16 @@
+﻿using ems_back.Repo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ems_back.Repo.DTOs
+{
+	public class CreateOrganizationUserDto
+	{
+		public Guid OrganizationId { get; set; }
+		public Guid UserId { get; set; }
+		public UserRole UserRole { get; set; } = UserRole.Participant;
+	}
+}

--- a/ems-back.Repo/DTOs/OrganizationUserDto.cs
+++ b/ems-back.Repo/DTOs/OrganizationUserDto.cs
@@ -1,0 +1,22 @@
+﻿using ems_back.Repo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ems_back.Repo.DTOs
+{
+	public class OrganizationUserDto
+	{
+		public Guid Id { get; set; }
+		public Guid OrganizationId { get; set; }
+		public string OrganizationName { get; set; }
+		public Guid UserId { get; set; }
+		public string UserFullName { get; set; }
+		public string UserEmail { get; set; }
+		public UserRole UserRole { get; set; }
+		public bool IsOrganizationAdmin { get; set; }
+		public DateTime JoinedAt { get; set; }
+	}
+}

--- a/ems-back.Repo/DTOs/UpdateOrganizationUserDto.cs
+++ b/ems-back.Repo/DTOs/UpdateOrganizationUserDto.cs
@@ -1,0 +1,15 @@
+﻿using ems_back.Repo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ems_back.Repo.DTOs
+{
+	public class UpdateOrganizationUserDto
+	{
+		public UserRole UserRole { get; set; }
+		public bool IsOrganizationAdmin { get; set; }
+	}
+}

--- a/ems-back.Repo/Interfaces/IOrganizationUserRepository.cs
+++ b/ems-back.Repo/Interfaces/IOrganizationUserRepository.cs
@@ -1,0 +1,36 @@
+﻿using ems_back.Repo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ems_back.Repo.Interfaces
+{
+	public interface IOrganizationUserRepository
+	{
+		Task<OrganizationUser> GetByIdAsync(Guid id);
+		Task<IEnumerable<OrganizationUser>> GetByOrganizationIdAsync(Guid organizationId);
+		Task<IEnumerable<OrganizationUser>> GetByUserIdAsync(Guid userId);
+		Task<OrganizationUser> GetByOrganizationAndUserIdAsync(Guid organizationId, Guid userId);
+		Task AddAsync(OrganizationUser organizationUser);
+		Task UpdateAsync(OrganizationUser organizationUser);
+		Task RemoveAsync(Guid id);
+		Task RemoveByOrganizationAndUserIdAsync(Guid organizationId, Guid userId);
+		Task<bool> ExistsAsync(Guid organizationId, Guid userId);
+		Task<int> GetMemberCountAsync(Guid organizationId);
+		Task UpdateUserRoleAsync(Guid organizationId, Guid userId, UserRole newRole);
+
+		/*
+		   Copy
+		   GET    /api/organizationusers/organization/{orgId}    - Get all users in org
+		   GET    /api/organizationusers/user/{userId}           - Get all orgs for user
+		   GET    /api/organizationusers/{id}                    - Get specific relationship
+		   POST   /api/organizationusers                         - Create new relationship
+		   PUT    /api/organizationusers/{id}/role               - Update user role
+		   DELETE /api/organizationusers/{id}                    - Remove relationship
+		   GET    /api/organizationusers/organization/{orgId}/count - Get member count
+		*/
+	}
+}
+

--- a/ems-back.Repo/MappingProfiles/DbMappingProfile.cs
+++ b/ems-back.Repo/MappingProfiles/DbMappingProfile.cs
@@ -147,6 +147,37 @@ namespace ems_back.Repo.MappingProfiles
 			CreateMap<Action, ActionDto>();
 			CreateMap<Action, ActionDetailedDto>();
 
+			// Add these mappings to your existing DbMappingProfile class
+			CreateMap<OrganizationUser, OrganizationUserDto>()
+				.ForMember(dest => dest.UserFullName,
+					opt => opt.MapFrom(src => $"{src.UserFirstName} {src.UserLastName}"));
+
+			CreateMap<CreateOrganizationUserDto, OrganizationUser>()
+				.ForMember(dest => dest.JoinedAt, opt => opt.MapFrom(_ => DateTime.UtcNow))
+				.ForMember(dest => dest.IsOrganizationAdmin,
+					opt => opt.MapFrom(src => src.UserRole == UserRole.Admin))
+				.ForMember(dest => dest.UserFirstName, opt => opt.Ignore())  // Will be set from User
+				.ForMember(dest => dest.UserLastName, opt => opt.Ignore())   // Will be set from User
+				.ForMember(dest => dest.UserEmail, opt => opt.Ignore())      // Will be set from User
+				.ForMember(dest => dest.OrganizationName, opt => opt.Ignore()) // Will be set from Organization
+				.ForMember(dest => dest.OrganizationAddress, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationDescription, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationProfilePicture, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationWebsite, opt => opt.Ignore());
+
+			CreateMap<UpdateOrganizationUserDto, OrganizationUser>()
+				.ForMember(dest => dest.UserId, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationId, opt => opt.Ignore())
+				.ForMember(dest => dest.JoinedAt, opt => opt.Ignore())
+				.ForMember(dest => dest.UserFirstName, opt => opt.Ignore())
+				.ForMember(dest => dest.UserLastName, opt => opt.Ignore())
+				.ForMember(dest => dest.UserEmail, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationName, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationAddress, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationDescription, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationProfilePicture, opt => opt.Ignore())
+				.ForMember(dest => dest.OrganizationWebsite, opt => opt.Ignore());
+
 		}
 	}
 }

--- a/ems-back.Repo/Migrations/20250403201021_AddOrganizationUserTable.Designer.cs
+++ b/ems-back.Repo/Migrations/20250403201021_AddOrganizationUserTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ems_back.Repo.Data;
@@ -11,9 +12,11 @@ using ems_back.Repo.Data;
 namespace ems_back.Repo.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250403201021_AddOrganizationUserTable")]
+    partial class AddOrganizationUserTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ems-back.Repo/Migrations/20250403201021_AddOrganizationUserTable.cs
+++ b/ems-back.Repo/Migrations/20250403201021_AddOrganizationUserTable.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ems_back.Repo.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationUserTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizationUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    OrganizationAddress = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    OrganizationDescription = table.Column<string>(type: "text", nullable: true),
+                    OrganizationProfilePicture = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    OrganizationWebsite = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserFirstName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    UserLastName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    UserEmail = table.Column<string>(type: "text", nullable: false),
+                    UserRole = table.Column<int>(type: "integer", nullable: false),
+                    UserProfilePicture = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    IsOrganizationAdmin = table.Column<bool>(type: "boolean", nullable: false),
+                    JoinedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationUsers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationUsers_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrganizationUsers_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationUsers_IsOrganizationAdmin",
+                table: "OrganizationUsers",
+                column: "IsOrganizationAdmin");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationUsers_OrganizationId_UserId",
+                table: "OrganizationUsers",
+                columns: new[] { "OrganizationId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationUsers_UserEmail",
+                table: "OrganizationUsers",
+                column: "UserEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationUsers_UserId",
+                table: "OrganizationUsers",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationUsers_UserRole",
+                table: "OrganizationUsers",
+                column: "UserRole");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationUsers");
+        }
+    }
+}

--- a/ems-back.Repo/Models/OrganizationUser.cs
+++ b/ems-back.Repo/Models/OrganizationUser.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+
+namespace ems_back.Repo.Models
+{
+	[Table("OrganizationUsers")]
+	public class OrganizationUser
+	{
+		[Key]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public Guid Id { get; set; } = Guid.NewGuid();
+
+		// Organization Information
+		[Required]
+		public Guid OrganizationId { get; set; }
+
+		[Required]
+		[MaxLength(255)]
+		public string OrganizationName { get; set; }
+
+		[MaxLength(500)]
+		public string OrganizationAddress { get; set; }
+
+		[Column(TypeName = "text")]
+		public string? OrganizationDescription { get; set; }
+
+		[MaxLength(255)]
+		public string? OrganizationProfilePicture { get; set; }
+
+		[MaxLength(255)]
+		public string? OrganizationWebsite { get; set; }
+
+		// User Information
+		[Required]
+		public Guid UserId { get; set; }
+
+		[Required]
+		[MaxLength(100)]
+		public string UserFirstName { get; set; }
+
+		[Required]
+		[MaxLength(100)]
+		public string UserLastName { get; set; }
+
+		[Required]
+		[EmailAddress]
+		public string UserEmail { get; set; }
+
+		[Required]
+		public UserRole UserRole { get; set; } = UserRole.Participant;
+
+		[MaxLength(255)]
+		public string? UserProfilePicture { get; set; }
+
+		// Relationship metadata
+		[Required]
+		public bool IsOrganizationAdmin { get; set; } = false;
+
+		[Required]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
+
+		// Navigation properties
+		[ForeignKey("OrganizationId")]
+		public virtual Organization Organization { get; set; }
+
+		[ForeignKey("UserId")]
+		public virtual User User { get; set; }
+
+	}
+}

--- a/ems-back.Repo/Models/organization.cs
+++ b/ems-back.Repo/Models/organization.cs
@@ -50,5 +50,6 @@ namespace ems_back.Repo.Models
 		public virtual User Updater { get; set; }
 
 		public virtual ICollection<User> Members { get; set; } = new HashSet<User>();
+		public virtual ICollection<OrganizationUser> OrganizationUsers { get; set; } = new HashSet<OrganizationUser>();
 	}
 }

--- a/ems-back.Repo/Models/user.cs
+++ b/ems-back.Repo/Models/user.cs
@@ -46,6 +46,7 @@ namespace ems_back.Repo.Models
 		public virtual ICollection<Event> CreatedEvents { get; set; } = new List<Event>();
 		public virtual ICollection<EventAttendee> AttendedEvents { get; set; } = new List<EventAttendee>();
 
+		public virtual ICollection<OrganizationUser> OrganizationUsers { get; set; } = new HashSet<OrganizationUser>();
 		[NotMapped]
 		public string FullName => $"{FirstName} {LastName}";
 	}

--- a/ems-back.Repo/Repository/OrganizationUserRepository.cs
+++ b/ems-back.Repo/Repository/OrganizationUserRepository.cs
@@ -1,0 +1,103 @@
+﻿using ems_back.Repo.Data;
+using ems_back.Repo.Interfaces;
+using ems_back.Repo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace ems_back.Repo.Repository
+{
+	public class OrganizationUserRepository : IOrganizationUserRepository
+	{
+		private readonly ApplicationDbContext _context;
+
+		public OrganizationUserRepository(ApplicationDbContext context)
+		{
+			_context = context;
+		}
+
+		public async Task<OrganizationUser> GetByIdAsync(Guid id)
+		{
+			return await _context.OrganizationUsers
+				.FirstOrDefaultAsync(ou => ou.Id == id);
+		}
+
+		public async Task<IEnumerable<OrganizationUser>> GetByOrganizationIdAsync(Guid organizationId)
+		{
+			return await _context.OrganizationUsers
+				.Where(ou => ou.OrganizationId == organizationId)
+				.ToListAsync();
+		}
+
+		public async Task<IEnumerable<OrganizationUser>> GetByUserIdAsync(Guid userId)
+		{
+			return await _context.OrganizationUsers
+				.Where(ou => ou.UserId == userId)
+				.ToListAsync();
+		}
+
+		public async Task<OrganizationUser> GetByOrganizationAndUserIdAsync(Guid organizationId, Guid userId)
+		{
+			return await _context.OrganizationUsers
+				.FirstOrDefaultAsync(ou => ou.OrganizationId == organizationId && ou.UserId == userId);
+		}
+
+		public async Task AddAsync(OrganizationUser organizationUser)
+		{
+			await _context.OrganizationUsers.AddAsync(organizationUser);
+			await _context.SaveChangesAsync();
+		}
+
+		public async Task UpdateAsync(OrganizationUser organizationUser)
+		{
+			_context.OrganizationUsers.Update(organizationUser);
+			await _context.SaveChangesAsync();
+		}
+
+		public async Task RemoveAsync(Guid id)
+		{
+			var organizationUser = await GetByIdAsync(id);
+			if (organizationUser != null)
+			{
+				_context.OrganizationUsers.Remove(organizationUser);
+				await _context.SaveChangesAsync();
+			}
+		}
+
+		public async Task RemoveByOrganizationAndUserIdAsync(Guid organizationId, Guid userId)
+		{
+			var organizationUser = await GetByOrganizationAndUserIdAsync(organizationId, userId);
+			if (organizationUser != null)
+			{
+				_context.OrganizationUsers.Remove(organizationUser);
+				await _context.SaveChangesAsync();
+			}
+		}
+
+		public async Task<bool> ExistsAsync(Guid organizationId, Guid userId)
+		{
+			return await _context.OrganizationUsers
+				.AnyAsync(ou => ou.OrganizationId == organizationId && ou.UserId == userId);
+		}
+
+		public async Task<int> GetMemberCountAsync(Guid organizationId)
+		{
+			return await _context.OrganizationUsers
+				.CountAsync(ou => ou.OrganizationId == organizationId);
+		}
+
+		public async Task UpdateUserRoleAsync(Guid organizationId, Guid userId, UserRole newRole)
+		{
+			var organizationUser = await GetByOrganizationAndUserIdAsync(organizationId, userId);
+			if (organizationUser != null)
+			{
+				organizationUser.UserRole = newRole;
+				organizationUser.IsOrganizationAdmin = newRole == UserRole.Admin;
+				await UpdateAsync(organizationUser);
+			}
+		}
+	}
+}

--- a/ems-back/Controllers/OrganizationUsersController.cs
+++ b/ems-back/Controllers/OrganizationUsersController.cs
@@ -1,0 +1,106 @@
+﻿using AutoMapper;
+using ems_back.Repo.DTOs;
+using ems_back.Repo.Interfaces;
+using ems_back.Repo.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ems_back.Controllers
+{
+
+	namespace ems_back.Controllers
+	{
+		[Route("api/[controller]")]
+		[ApiController]
+		[Authorize]
+		public class OrganizationUsersController : ControllerBase
+		{
+			private readonly IOrganizationUserRepository _repository;
+			private readonly IMapper _mapper;
+
+			public OrganizationUsersController(
+				IOrganizationUserRepository repository,
+				IMapper mapper)
+			{
+				_repository = repository;
+				_mapper = mapper;
+			}
+
+			// GET: api/organizationusers/organization/{orgId}
+			[HttpGet("organization/{orgId}")]
+			public async Task<ActionResult<IEnumerable<OrganizationUserDto>>> GetByOrganization(Guid orgId)
+			{
+				var orgUsers = await _repository.GetByOrganizationIdAsync(orgId);
+				return Ok(_mapper.Map<IEnumerable<OrganizationUserDto>>(orgUsers));
+			}
+
+			// GET: api/organizationusers/user/{userId}
+			[HttpGet("user/{userId}")]
+			public async Task<ActionResult<IEnumerable<OrganizationUserDto>>> GetByUser(Guid userId)
+			{
+				var userOrgs = await _repository.GetByUserIdAsync(userId);
+				return Ok(_mapper.Map<IEnumerable<OrganizationUserDto>>(userOrgs));
+			}
+
+			// GET: api/organizationusers/{id}
+			[HttpGet("{id}")]
+			public async Task<ActionResult<OrganizationUserDto>> GetById(Guid id)
+			{
+				var orgUser = await _repository.GetByIdAsync(id);
+				if (orgUser == null) return NotFound();
+				return Ok(_mapper.Map<OrganizationUserDto>(orgUser));
+			}
+
+			// POST: api/organizationusers
+			[HttpPost]
+			public async Task<ActionResult<OrganizationUserDto>> Create([FromBody] CreateOrganizationUserDto dto)
+			{
+				if (await _repository.ExistsAsync(dto.OrganizationId, dto.UserId))
+					return Conflict("User already exists in this organization");
+
+				var orgUser = _mapper.Map<OrganizationUser>(dto);
+				orgUser.JoinedAt = DateTime.UtcNow;
+				orgUser.IsOrganizationAdmin = dto.UserRole == UserRole.Admin;
+
+				await _repository.AddAsync(orgUser);
+
+				return CreatedAtAction(nameof(GetById),
+					new { id = orgUser.Id },
+					_mapper.Map<OrganizationUserDto>(orgUser));
+			}
+
+			// PUT: api/organizationusers/{id}/role
+			[HttpPut("{id}/role")]
+			public async Task<IActionResult> UpdateRole(Guid id, [FromBody] UpdateOrganizationUserDto dto)
+			{
+				var orgUser = await _repository.GetByIdAsync(id);
+				if (orgUser == null) return NotFound();
+
+				orgUser.UserRole = dto.UserRole;
+				orgUser.IsOrganizationAdmin = dto.UserRole == UserRole.Admin;
+
+				await _repository.UpdateAsync(orgUser);
+				return NoContent();
+			}
+
+			// DELETE: api/organizationusers/{id}
+			[HttpDelete("{id}")]
+			public async Task<IActionResult> Delete(Guid id)
+			{
+				var orgUser = await _repository.GetByIdAsync(id);
+				if (orgUser == null) return NotFound();
+
+				await _repository.RemoveAsync(id);
+				return NoContent();
+			}
+
+			// GET: api/organizationusers/organization/{orgId}/count
+			[HttpGet("organization/{orgId}/count")]
+			public async Task<ActionResult<int>> GetMemberCount(Guid orgId)
+			{
+				var count = await _repository.GetMemberCountAsync(orgId);
+				return Ok(count);
+			}
+		}
+	}
+}

--- a/ems-back/Program.cs
+++ b/ems-back/Program.cs
@@ -28,9 +28,12 @@ namespace ems_back
             builder.Services.AddScoped<IAgendaEntryRepository, AgendaEntryRepository>();
             builder.Services.AddScoped<IFlowRepository, FlowRepository>();
             builder.Services.AddScoped<ITriggerRepository, TriggerRepository>();
-			// Add services to the container.
+            builder.Services.AddScoped<IOrganizationUserRepository, OrganizationUserRepository>();
 
-			builder.Services.AddControllers();
+
+            // Add services to the container.
+
+            builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();


### PR DESCRIPTION
- Created OrganizationUser entity, repository, and controller
- Implemented CRUD operations for organization-user relationships
- Added DTOs for OrganizationUser operations
- Configured AutoMapper mappings for OrganizationUser
- Established proper EF Core relationships between User/Organization
- Added unique constraint to prevent duplicate user-org relationships
- Implemented automatic timestamping for relationship creation
- Configured cascade delete behavior for related entities

This enables:
- Tracking which users belong to which organizations
- Managing user roles within organizations
- Querying organization memberships